### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,16 +1,16 @@
-  RF24 KEYWORD1
-  begin KEYWORD2
-  setChannel KEYWORD2
-  setPayloadSize KEYWORD2
-  getPayloadSize KEYWORD2
-  print_details KEYWORD2
-  startListening KEYWORD2
-  stopListening KEYWORD2
-  write KEYWORD2
+  RF24	KEYWORD1
+  begin	KEYWORD2
+  setChannel	KEYWORD2
+  setPayloadSize	KEYWORD2
+  getPayloadSize	KEYWORD2
+  print_details	KEYWORD2
+  startListening	KEYWORD2
+  stopListening	KEYWORD2
+  write	KEYWORD2
   writeFast	KEYWORD2
   writeBlocking	KEYWORD2
   txStandBy	KEYWORD2
-  available KEYWORD2
-  read KEYWORD2
-  openWritingPipe KEYWORD2
-  openReadingPipe KEYWORD2
+  available	KEYWORD2
+  read	KEYWORD2
+  openWritingPipe	KEYWORD2
+  openReadingPipe	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords